### PR TITLE
Update comment in entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,8 @@ fi
 # ─── 2) START PHASE ────────────────────────────────────────────────────────────
 cd /home/container
 
-# 2.1) Pick the recorded JRE version (or default)
+# 2.1) Pick the recorded JRE version.
+#      Reads .javaver if non-empty, otherwise uses $JAVA_VERSION.
 JAVA_VER="$(cat .javaver 2>/dev/null || true)"
 [[ -n "$JAVA_VER" ]] || JAVA_VER="$JAVA_VERSION"
 export JAVA_HOME="${JAVA_DIR}/java${JAVA_VER}"


### PR DESCRIPTION
## Summary
- clarify comment on how the JRE version is selected

## Testing
- `bash -n entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841cdd7cf24832387d4b22f0f75a738